### PR TITLE
Infill calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+render/config/
+slicer/config/
+slicer/tmp/

--- a/render/package.json
+++ b/render/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "printrapp-render",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "mick",
+  "license": "ISC",
+  "dependencies": {
+    "aws-sdk": "^2.1.38",
+    "bluebird": "^3.4.1",
+    "caman": "^4.1.2",
+    "hat": "0.0.3",
+    "jimp": "^0.2.24"
+  }
+}
+

--- a/slicer/app.js
+++ b/slicer/app.js
@@ -93,7 +93,7 @@ function buildSimpleConfig(inFilePath, outFilePath,  params) {
     // Calculate infill_line_distance override based on desired density. Default to
     // standard density if not specified or unknown value specified.
     var infill_sparse_density = infillConfig[params.infill];
-    if (!infill_sparse_density) {
+    if (infill_sparse_density === null) {
       console.warn("Unknown infill specified: '%s', defaulting to 'standard'", params.infill);
       infill_sparse_density = infillConfig.standard;
     }
@@ -101,7 +101,10 @@ function buildSimpleConfig(inFilePath, outFilePath,  params) {
 
     // Note that we're multiplying by 100, rounding, and then dividing by 100 again to get a value rounded
     // to 2 decimal places
-    var line_distance = ((infill_line_width * 100.0) / infill_sparse_density) * infillPatternMultiplier;
+    var line_distance = 0.0;
+    if (infill_sparse_density > 0) {
+        line_distance = ((infill_line_width * 100.0) / infill_sparse_density) * infillPatternMultiplier;
+    }
     jsonConfig.overrides.infill_line_distance = { "default_value": Math.round(line_distance * 100, 2) / 100.0 }
     console.info("Calculated infill_line_distance = %f", jsonConfig.overrides.infill_line_distance.default_value);
 

--- a/slicer/app.js
+++ b/slicer/app.js
@@ -8,10 +8,8 @@ var AWS = require('aws-sdk')
   , MessageQueue = require('./util/message_queue.js')
   , FileRepo = require('./util/file_repo.js');
 
-
 var sqs = new AWS.SQS();
 var CuraEngine = /darwin/.test(process.platform) ? 'CuraEngine_darwin' : 'CuraEngine';
-
 
 function runLoop() {
   MessageQueue.poolMessage(ac.sqs_run)
@@ -26,9 +24,9 @@ function runLoop() {
 function runSlicer(configFile, stl, gcodeFilePath) {
   return new Promise(function(resolve, reject) {
     console.info('-- SLICE');
-    var cmd = "CURA_ENGINE_SEARCH_PATH=./ ./"+CuraEngine+" slice -v -j "+configFile+" -l "+stl;
+    var cmd = "CURA_ENGINE_SEARCH_PATH=./ ./" + CuraEngine + " slice -v -j " + configFile + " -l " + stl;
     cmd += " -s mesh_position_z=\"0\" -s center_object=\"true\"";
-    cmd += " -o "+gcodeFilePath;
+    cmd += " -o " + gcodeFilePath;
     console.info(cmd);
     exec(cmd, function callback(err, stdout, stderr) {
       if (err) {
@@ -44,63 +42,63 @@ function runSlicer(configFile, stl, gcodeFilePath) {
   });
 }
 
+var resolutionConfig = {
+  'low': 0.2,
+  'standard': 0.1,
+  'high': 0.05
+};
 
+var infillConfig = {
+  'hollow': 0.0,
+  'sparse': 10.0,
+  'standard': 20.0,
+  'dense': 30.0,
+  'solid': 70.0,
+  /* Deprecated, retained for backward compatibility */
+  'light': 10.0,
+  'medium': 20.0,
+  'heavy': 50.0
+}
+
+/**
+ * Set CuraEngine overrides based on print settings parameters.
+ */
 function buildSimpleConfig(inFilePath, outFilePath,  params) {
   return new Promise(function(resolve, reject) {
     var jsonConfig = require(inFilePath);
 
-    // resolution
-    switch(params.resolution) {
-      case 'low':
-        jsonConfig.overrides.layer_height = { "default_value": 0.2 };
-        break;
-
-      case 'standard':
-        jsonConfig.overrides.layer_height = { "default_value": 0.1 };
-        break;
-
-      case 'high':
-        jsonConfig.overrides.layer_height = { "default_value": 0.05 };
-        break;
+    // Set layer_height override. Default to standard resolution if not specified
+    // or unknown value specified.
+    var resolution = resolutionConfig[params.resolution];
+    if (!resolution) {
+      console.warn("Unknown resolution specified: '%s', defaulting to 'standard'", params.resolution);
+      resolution = resolutionConfig.standard;
     }
+    jsonConfig.overrides.layer_height = { "default_value": resolution };
 
-    // infill
-    switch(params.infill) {
-      case 'hollow':
-        jsonConfig.overrides.infill_sparse_density = { "default_value": 0 };
-        break;
-
-      case 'light':
-        jsonConfig.overrides.infill_sparse_density = { "default_value": 5 };
-        break;
-
-      case 'standard':
-        jsonConfig.overrides.infill_sparse_density = { "default_value": 20 };
-        break;
-
-      case 'medium':
-        jsonConfig.overrides.infill_sparse_density = { "default_value": 30 };
-        break;
-
-      case 'heavy':
-        jsonConfig.overrides.infill_sparse_density = { "default_value": 50 };
-        break;
-
-      case 'solid':
-        jsonConfig.overrides.infill_sparse_density = { "default_value": 100 };
-        break;
+    // Calculate infill_line_distance override based on desired density. Default to
+    // standard density if not specified or unknown value specified.
+    var infill_sparse_density = infillConfig[params.infill];
+    if (!infill_sparse_density) {
+      console.warn("Unknown infill specified: '%s', defaulting to 'standard'", params.infill);
+      infill_sparse_density = infillConfig.standard;
     }
+    // Note that `(resolution * 100.0) / infill_sparse_density` gives us the real result and the rest
+    // is to force rounding to a maximum of 2 decimal places
+    var infill_line_distance = Math.round(((resolution * 100.0) / infill_sparse_density) * 100, 2) / 100.0;
+    jsonConfig.overrides.infill_line_distance = { "default_value": infill_line_distance }
 
-    // support
-    if (params.support)
+    // Set support_enable override if support enabled. Default to false if not specified.
+    if (params.support) {
       jsonConfig.overrides.support_enable = { "default_value": true };
-    else
+    } else {
       jsonConfig.overrides.support_enable = { "default_value": false };
+    }
 
-
-    // brim
-    if (params.brim)
+    // Set adhesion_type override to Brim if brim enabled. Do not set if not specified.
+    if (params.brim) {
       jsonConfig.overrides.adhesion_type = { "default_value": "Brim" };
+    }
 
     // write config to file
     fs.writeFile(outFilePath, JSON.stringify(jsonConfig), 'utf8', function(err, res) {
@@ -147,7 +145,6 @@ function getLinesCount(filePath) {
     });
   })
 }
-
 
 function writeGcodeHeader(inFilePath, slicerOut, event) {
   console.info("-- WRITING GCODE HEADER ");
@@ -208,12 +205,12 @@ function sliceStl(res) {
       return reject("Required parameters missing");
 
     var s3 = new AWS.S3()
-      , keyPath = 'u/'+(event.user)+'/i/'+(event.id)+'/'
-      , stlFilePath = "/tmp/obj_"+(event.id)+".stl"
+      , keyPath = 'u/' + (event.user) + '/i/' + (event.id) + '/'
+      , stlFilePath = "/tmp/obj_" + (event.id) + ".stl"
       , bucket = 'files.printrapp.com'
       , configDefault = './simple.json'
-      , configOut = '/tmp/config_'+(event.id)+'.json'
-      , gcodeFilePath = '/tmp/out_'+(event.id)+'.gco'
+      , configOut = '/tmp/config_' + (event.id) + '.json'
+      , gcodeFilePath = '/tmp/out_' + (event.id) + '.gco'
 
     // download stl
     FileRepo.downloadFromS3(event.file_path, stlFilePath)

--- a/slicer/fdmprinter.def.json
+++ b/slicer/fdmprinter.def.json
@@ -2299,7 +2299,7 @@
                         "buildplate": "Touching Buildplate",
                         "everywhere": "Everywhere"
                     },
-                    "default_value": "everywhere",
+                    "default_value": "buildplate",
                     "enabled": "support_enable",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false

--- a/slicer/package.json
+++ b/slicer/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "aws-sdk": "^2.7.23",
     "bluebird": "^3.4.7",
+    "hat": "0.0.3",
     "https": "^1.0.0"
   }
 }


### PR DESCRIPTION
- Update list of supported infill options: Hollow (0%), Sparse (10%), Standard (20%), Dense (30%), Solid (70%)
- Deprecate options for to retain backward compatibility: Light (10%), Medium (20%), Heavy (50%)
- Calculate infill line distance based selected resolution (layer height) and density. 